### PR TITLE
Fix diffing new files added between branches

### DIFF
--- a/bake/covered/git.rb
+++ b/bake/covered/git.rb
@@ -45,7 +45,7 @@ end
 def lines_modified(branch)
 	result = Hash.new{|k,v| k[v] = Set.new}
 	
-	diff = repository.diff_workdir(branch)
+	diff = repository.diff(repository.rev_parse(branch), repository.last_commit)
 	
 	diff.each_patch do |patch|
 		path = patch.delta.new_file[:path]


### PR DESCRIPTION
Fixes an issue where creating a new file that isn't present in the base branch would cause that file to not show up in the output of the bake task.

Previously it would only include files present in the base branch.